### PR TITLE
fix(developers): revert classes

### DIFF
--- a/scss/theme/pages/_developers.scss
+++ b/scss/theme/pages/_developers.scss
@@ -59,8 +59,8 @@ body {
     }
 
     // Inputs
-    .input_d266e7,
-    .inputWrapper_b7205b {
+    .input-2g-os5,
+    .inputWrapper-3a4ywb {
         border-color: var(--background-secondary);
         background-color: var(--input-background);
     }
@@ -85,24 +85,24 @@ body {
         }
     }
     // Paginator
-    .disabled__238bc,
-    .disabled__238bc:hover {
+    .disabled-29cfPA,
+    .disabled-29cfPA:hover {
         border-color: var(--background-secondary);
         background-color: var(--background-tertiary);
     }
-    .disabled__238bc + .pageButtonNext_b6c1ca,
-    .disabled__238bc + .pageCount-17vMJm,
-    .disabled__238bc:hover + .pageButtonNext_b6c1ca,
-    .disabled__238bc:hover + .pageCount-17vMJm,
-    .pageButtonNext_b6c1ca,
+    .disabled-29cfPA + .pageButtonNext-2_bbdk,
+    .disabled-29cfPA + .pageCount-17vMJm,
+    .disabled-29cfPA:hover + .pageButtonNext-2_bbdk,
+    .disabled-29cfPA:hover + .pageCount-17vMJm,
+    .pageButtonNext-2_bbdk,
     .pageCount-17vMJm,
-    .pageButtonNext_b6c1ca,
-    .pageButtonPrev__9ee28 {
+    .pageButtonNext-2_bbdk,
+    .pageButtonPrev-3q9rh8 {
         border-color: var(--background-secondary) !important;
         background-color: var(--background-tertiary);
     }
-    .pageButtonNext_b6c1ca:hover,
-    .pageButtonPrev__9ee28:hover {
+    .pageButtonNext-2_bbdk:hover,
+    .pageButtonPrev-3q9rh8:hover {
         border-color: var(--background-secondary-alt) !important;
         background-color: var(--background-secondary);
     }


### PR DESCRIPTION
This page shouldn't have been changed. It was causing issues with the theme as the developers web page hasn't been updated and most likely won't be updated with the new classes (didn't even switch to swc).

For example:
![image](https://github.com/MiniDiscordThemes/AMOLEDCord/assets/38290480/8e587a3a-3f15-45e5-89a4-aebd165f5236)
